### PR TITLE
Adjust README formatting and clean up test files

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Configure when notifications should appear:
 ```
 
 **Available Triggers:**
+
 - `onSave`: Show notification when saving files (default: enabled)
 - `onEdit`: Show notification while editing after a delay (default: disabled, 5 seconds delay)
 - `onOpen`: Show notification when opening files (default: disabled)

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -17,7 +17,7 @@ suite('Extension Test Suite', () => {
 	test('Should have triggers configuration', () => {
 		const config = vscode.workspace.getConfiguration('codeMantra');
 		const triggers = config.get('triggers');
-		
+
 		assert.ok(triggers);
 		assert.strictEqual(typeof triggers, 'object');
 	});
@@ -25,7 +25,7 @@ suite('Extension Test Suite', () => {
 	test('Should have fileTypes configuration', () => {
 		const config = vscode.workspace.getConfiguration('codeMantra');
 		const fileTypes = config.get<string[]>('fileTypes');
-		
+
 		assert.ok(Array.isArray(fileTypes));
 		assert.ok(fileTypes!.length > 0);
 	});
@@ -33,7 +33,7 @@ suite('Extension Test Suite', () => {
 	test('Should have excludePatterns configuration', () => {
 		const config = vscode.workspace.getConfiguration('codeMantra');
 		const excludePatterns = config.get<string[]>('excludePatterns');
-		
+
 		assert.ok(Array.isArray(excludePatterns));
 	});
 });


### PR DESCRIPTION
Refine the README by adjusting empty lines and removing unnecessary whitespace from test files to enhance readability.